### PR TITLE
Fix `type` argument definition of `toHaveQueryParam` matcher interface

### DIFF
--- a/src/@types/jest.d.ts
+++ b/src/@types/jest.d.ts
@@ -1,12 +1,10 @@
 namespace jest {
-  import { QueryParamConfig } from 'serialize-query-params'
-
   interface Matchers<R> {
     toHaveQueryParam(
       expectedQueryParam: {
         name: string;
         value: any;
-        type: QueryParamConfig<any, any>
+        type: import('serialize-query-params').QueryParamConfig<any, any>
       }
     ): CustomMatcherResult;
   }

--- a/src/matchers/toHaveQueryParam/helpers.ts
+++ b/src/matchers/toHaveQueryParam/helpers.ts
@@ -10,7 +10,7 @@ export interface ExpectedQueryParam {
   value: any;
 }
 
-type EncodedValue = string | string[] | null | (string | null)[] | undefined
+type EncodedValue = string | string[] | null
 
 export const validateArguments = ({
   name,
@@ -59,17 +59,13 @@ export const encodeValues = ({
   }
 }
 
-export const validateResult = ({
+export const validateValues = ({
   name,
   value,
   encodedExpectedValue,
   encodedReceivedValue,
   decodedReceivedValue
-}: Pick<ExpectedQueryParam, 'name' | 'value'> & {
-  encodedReceivedValue: EncodedValue,
-  encodedExpectedValue: EncodedValue,
-  decodedReceivedValue: EncodedValue
-}) => {
+}: Pick<ExpectedQueryParam, 'name' | 'value'> & ReturnType<typeof encodeValues>) => {
   throw new CustomMatcherMessage({
     pass: isEqual(decodedReceivedValue, value),
     message: () => `${name} query param is expected to be ${encodedExpectedValue} but the received value is ${encodedReceivedValue}`

--- a/src/matchers/toHaveQueryParam/index.ts
+++ b/src/matchers/toHaveQueryParam/index.ts
@@ -1,6 +1,6 @@
 import {
   encodeValues,
-  validateResult,
+  validateValues,
   validateArguments,
   ExpectedQueryParam
 } from './helpers'
@@ -32,7 +32,7 @@ export const toHaveQueryParam = (
       encodedReceivedValue
     })
 
-    validateResult({
+    validateValues({
       name,
       value,
       encodedExpectedValue,


### PR DESCRIPTION
Follow up from https://github.com/LauraBeatris/react-router-testing-utils/pull/3 checklist

Fix `type` definition since it was previously being loaded as `any` due to passing `QueryParamConfig` without the generic arguments, as `QueryParamConfig<any, any>` 

I also did a few unrelated changes regarding code style such as function renaming and improving some type definitions 