### PR TITLE
Fix dependencies and export extend expect file

### DIFF
--- a/extend-expect.ts
+++ b/extend-expect.ts
@@ -1,0 +1,3 @@
+import * as extensions from './src/matchers'
+
+expect.extend(extensions)

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist",
-    "src"
+    "src",
+    "extend-expect.ts"
   ],
   "engines": {
     "node": ">=10"
@@ -43,14 +44,22 @@
       "limit": "70 KB"
     }
   ],
-  "devDependencies": {
-    "@size-limit/preset-small-lib": "^4.10.2",
-    "@testing-library/jest-dom": "^5.11.10",
+  "dependencies": {
     "@testing-library/react": "^11.2.6",
     "@types/lodash.isequal": "^4.5.5",
     "@types/react": "^17.0.3",
     "@types/react-router-dom": "^5.1.7",
-    "@types/testing-library__jest-dom": "^5.9.5",
+    "history": "^5.0.0",
+    "lodash.isequal": "^4.5.0",
+    "query-string": "^7.0.0",
+    "react-router-dom": "^5.2.0",
+    "serialize-query-params": "^1.3.3",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  },
+  "devDependencies": {
+    "@size-limit/preset-small-lib": "^4.10.2",
+    "@testing-library/jest-dom": "^5.11.10",
     "@typescript-eslint/eslint-plugin": "^4.22.0",
     "@typescript-eslint/parser": "^4.22.0",
     "babel-eslint": "^10.1.0",
@@ -66,13 +75,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.20.3",
     "eslint-plugin-react-hooks": "^4.0.8",
-    "history": "^5.0.0",
     "husky": "^6.0.0",
-    "lodash.isequal": "^4.5.0",
-    "query-string": "^7.0.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-router-dom": "^5.2.0",
     "size-limit": "^4.10.2",
     "ts-jest": "^26.5.5",
     "tsdx": "^0.14.1",

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,2 +1,2 @@
 import '@testing-library/jest-dom'
-import './src/extend-expect'
+import './extend-expect'

--- a/src/extend-expect.ts
+++ b/src/extend-expect.ts
@@ -1,3 +1,0 @@
-import * as extensions from './matchers'
-
-expect.extend(extensions)

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,10 +835,17 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
   integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
+"@babel/runtime@^7.7.6":
+  version "7.13.17"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.17.tgz#8966d1fc9593bf848602f0662d6b4d0069e3a7ec"
+  integrity sha512-NCdgJEelPTSh+FEFylhnP1ylq848l1z9t9N0j1Lfbcw0+KXGjsTvUmkxy+voLLXB5SOKMbLLx4jxYliGrYQseA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1465,7 +1472,7 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/testing-library__jest-dom@^5.9.1", "@types/testing-library__jest-dom@^5.9.5":
+"@types/testing-library__jest-dom@^5.9.1":
   version "5.9.5"
   resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz#5bf25c91ad2d7b38f264b12275e5c92a66d849b0"
   integrity sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==


### PR DESCRIPTION
Fix dependencies by `devDependencies` and `dependencies` - All the dependencies were being set as `devDependencies`, which was wrong since dependencies like `query-string` are needed to run the `toHaveQueryParam` custom matcher. 

Add `extend-expect.ts` file to `files` property in `package.json` in order to be imported within the package. Eg: 

`setupTests.ts`
```js
import "react-router-testing-utils/extend-expect"
```